### PR TITLE
Fix typo in best speculator description

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
                     "",
                     "This view shows the performance of the S&P 500 over time.",
                     "This view shows the performance of the S&P 500 along with the portfolio of the worst speculator, who made the worst possible market timing decisions. The investor bought right before precipitous declines in the index value.",
-                    "This view shows the performance of the S&P 500 along with the portfolio of the best speculator, who made the best possible market timing decisions. th einvestory bought right before precipitous increases in the index value.",
+                    "This view shows the performance of the S&P 500 along with the portfolio of the best speculator, who made the best possible market timing decisions. the investor bought right before precipitous increases in the index value.",
                     "This view shows the performance of the S&P 500 along with the portfolio of an investor using Dollar-Cost Averaging (DCA), investing a fixed amount regularly regardless of the market conditions."
                 ];
 


### PR DESCRIPTION
## Summary
- correct misspelled phrase in the view descriptions

## Testing
- `grep -n "the investor" -n index.html`